### PR TITLE
fix: export JSONRPCLog type

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ npm install --save @open-rpc/logs-react
 ```
 ##### Usage:
 ```
-import JSONRPCLogger, {IJSONRPCLog} from "@open-rpc/logs-react";
+import JSONRPCLogger, {JSONRPCLog} from "@open-rpc/logs-react";
 
 // Get these logs how ever you want
-const logs: IJSONRPCLog[] = [{
+const logs: JSONRPCLog[] = [{
     type: "request",
     method: "test",
     timestamp: new Date(),
@@ -51,9 +51,9 @@ npm install @open-rpc/logs-react --save
 ```
 import React from 'react';
 import ReactDOM from 'react-dom';
-import JSONRPCLogger, {IJSONRPCLog} from "@open-rpc/logs-react";
+import JSONRPCLogger, {JSONRPCLog} from "@open-rpc/logs-react";
 
-const logs: IJSONRPCLog[] = [{
+const logs: JSONRPCLog[] = [{
     type: "request",
     method: "test",
     timestamp: new Date(),

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -1,2 +1,3 @@
-import JSONRPCLogger from "./components/logsReact/logsReact";
+import JSONRPCLogger, {IJSONRPCLog} from "./components/logsReact/logsReact";
+export type JSONRPCLog = IJSONRPCLog;
 export default JSONRPCLogger;


### PR DESCRIPTION
The JSONRPCLog type was not being exported and therefore could not be used when implementing logs-react