### PR TITLE
fix: slide animation is restricted to div

### DIFF
--- a/src/components/methodList/methodList.tsx
+++ b/src/components/methodList/methodList.tsx
@@ -41,6 +41,7 @@ const useStyles = makeStyles((theme: Theme) =>
       padding: "4 8 6",
     },
     drawer: {
+      overflow: "hidden",
       width: 200,
       flexShrink: 0,
     },


### PR DESCRIPTION
When closing the filters sidebar the animation no longer slides across the entire screen

fixes #51