### PR TITLE
fix: make add button hidden until needed

### DIFF
--- a/src/components/methodList/methodList.tsx
+++ b/src/components/methodList/methodList.tsx
@@ -150,12 +150,14 @@ const MethodList: React.FC<IProps> = (props) => {
                 </ListItemText>
               </ListItem>
             ))}
-            <ListItem button onClick={handleModalOpen} disabled={methods.length > 2 ? false : true}>
-              <ListItemIcon>{<AddCircleOutlineIcon />}</ListItemIcon>
-              <ListItemText>
-                add new filter
-              </ListItemText>
-            </ListItem>
+            <div style={methods.length > 2 ? {} : {display: 'none'}}>
+              <ListItem button onClick={handleModalOpen}>
+                <ListItemIcon>{<AddCircleOutlineIcon />}</ListItemIcon>
+                <ListItemText>
+                  add new filter
+                </ListItemText>
+              </ListItem>
+            </div>
           </List>
       </Drawer>
       <Modal


### PR DESCRIPTION
Add filters button used to be disabled when not needed. This was confusing to users so now it is hidden until it is needed.

fixes #62